### PR TITLE
Fix rename() EIO race with background upload for just-created files

### DIFF
--- a/MetadataIndex.py
+++ b/MetadataIndex.py
@@ -131,6 +131,31 @@ class MetadataIndex:
         self._deindex_item(item_id)
         self._delete_item_from_db(item_id)
 
+    def rebind(self, old_id, new_item):
+        """
+        Replace an item's id with a new one, preserving its inode.
+
+        Used when a provisional (`__pending__...`) entry is renamed before
+        its upload completes: the id string encodes name/parent and must
+        change, but the inode already handed to the kernel must not.
+        """
+        inode = self._id_to_inode.pop(old_id, None)
+        if inode is not None:
+            self._inode_to_id.pop(inode, None)
+
+        self._deindex_item(old_id)
+        self._delete_item_from_db(old_id)
+
+        new_id = new_item.get("id")
+        if inode is not None:
+            self._id_to_inode[new_id] = inode
+            self._inode_to_id[inode] = new_id
+
+        self._index_item(new_item)
+        self._maybe_update_root(new_item)
+        self._save_item_to_db(new_id, new_item)
+        self._inode_dirty = True
+
     # ------------------------------------------------------------------
     # Private: indexing
     # ------------------------------------------------------------------

--- a/OneDriveFUSE.py
+++ b/OneDriveFUSE.py
@@ -51,6 +51,7 @@ class _WriteHandle:
     name: str
     inode: int              # provisional or real inode
     size: int = 0           # current byte count (for getattr during write)
+    provisional_id: str | None = None  # index key while item_id is None
 
 # Processes that probe file content for thumbnails/indexing but should NOT
 # trigger on-demand downloads. Add entries as needed for your desktop env.
@@ -548,6 +549,7 @@ class OneDriveFUSE(pyfuse3.Operations):
             tmp_path=tmp.name, item_id=None,
             parent_id=parent_id, parent_inode=parent_inode,
             name=name, inode=inode, size=0,
+            provisional_id=None if is_temp else provisional_id,
         )
         logger.debug(f"create '{name}' (temp={is_temp}) fh={fh}")
         return pyfuse3.FileInfo(fh=fh), attrs
@@ -664,6 +666,41 @@ class OneDriveFUSE(pyfuse3.Operations):
             raise pyfuse3.FUSEError(errno.ENOENT)
 
         item_id = item["id"]
+
+        if item_id.startswith("__pending__"):
+            # Upload hasn't happened yet (create()/write() only touch the
+            # local temp file) — there is nothing on the server to rename.
+            # Rewrite the provisional index entry and the still-open write
+            # handle in place so the eventual upload lands under the new
+            # name/location, and skip the Graph API call entirely.
+            new_provisional_id = f"__pending__{name_new}__{parent_id_new}"
+            new_item = dict(item)
+            new_item["id"] = new_provisional_id
+            new_item["name"] = name_new
+            new_item["parentReference"] = {"id": parent_id_new}
+            self._index.rebind(item_id, new_item)
+
+            handle = next(
+                (h for h in self._write_handles.values()
+                 if h.provisional_id == item_id),
+                None,
+            )
+            if handle is not None:
+                handle.name = name_new
+                handle.parent_id = parent_id_new
+                handle.parent_inode = parent_inode_new
+                handle.provisional_id = new_provisional_id
+
+            for inv_inode in {parent_inode_old, parent_inode_new}:
+                try:
+                    pyfuse3.invalidate_inode(inv_inode, attr_only=False)
+                except Exception:
+                    pass
+            logger.info(
+                f"rename '{name_old}' → '{name_new}' (pending upload, local-only)"
+            )
+            return
+
         new_name = name_new if name_new != name_old else None
         new_parent = parent_id_new if parent_id_new != parent_id_old else None
 

--- a/tests/test_onedrive_fuse.py
+++ b/tests/test_onedrive_fuse.py
@@ -467,3 +467,83 @@ def test_open_404_removes_item_from_index_and_raises_enoent(fuse, index):
 def test_release_does_not_raise(fuse, index):
     inode = index.get_inode(FILE_ITEM["id"])
     trio.run(fuse.release, inode)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# rename (provisional / not-yet-uploaded items)
+#
+# Regression coverage for: rename() racing release()'s background upload.
+# create() only writes a local temp file and a provisional "__pending__..."
+# index entry; the real Graph upload happens later in release(). Renaming
+# in between must not hit the Graph API with a synthetic id.
+# ---------------------------------------------------------------------------
+
+def test_rename_pending_item_is_local_only_no_graph_call(fuse):
+    fi, _ = trio.run(
+        fuse.create, ROOT_INODE, b"project.json.tmp-999888777", 0o644,
+        os.O_WRONLY, _fake_ctx(),
+    )
+
+    with patch("OneDriveFUSE.move_rename_item") as mock_move:
+        trio.run(
+            fuse.rename, ROOT_INODE, b"project.json.tmp-999888777",
+            ROOT_INODE, b"project.json", 0, _fake_ctx(),
+        )
+
+    mock_move.assert_not_called()
+
+    item = fuse._index.lookup(ROOT_ID, "project.json")
+    assert item is not None
+    assert item["id"].startswith("__pending__")
+    assert fuse._index.lookup(ROOT_ID, "project.json.tmp-999888777") is None
+
+    handle = fuse._write_handles[fi.fh]
+    assert handle.name == "project.json"
+    assert handle.parent_id == ROOT_ID
+
+
+def test_rename_pending_item_preserves_inode(fuse):
+    """The kernel already knows the inode returned by create() — renaming
+    a pending item must not hand out a different one."""
+    fi, attrs = trio.run(
+        fuse.create, ROOT_INODE, b"draft.txt.tmp-1", 0o644,
+        os.O_WRONLY, _fake_ctx(),
+    )
+    original_inode = attrs.st_ino
+
+    with patch("OneDriveFUSE.move_rename_item"):
+        trio.run(
+            fuse.rename, ROOT_INODE, b"draft.txt.tmp-1",
+            ROOT_INODE, b"draft.txt", 0, _fake_ctx(),
+        )
+
+    item = fuse._index.lookup(ROOT_ID, "draft.txt")
+    assert fuse._index.get_inode(item["id"]) == original_inode
+
+
+def test_rename_pending_item_then_upload_uses_new_name(fuse):
+    """After a rename-before-upload, release()'s eventual upload must use
+    the new name/parent, not the one captured at create() time."""
+    fi, _ = trio.run(
+        fuse.create, ROOT_INODE, b"project.json.tmp-999888777", 0o644,
+        os.O_WRONLY, _fake_ctx(),
+    )
+    trio.run(fuse.write, fi.fh, 0, b'{"schema":1}')
+
+    with patch("OneDriveFUSE.move_rename_item"):
+        trio.run(
+            fuse.rename, ROOT_INODE, b"project.json.tmp-999888777",
+            ROOT_INODE, b"project.json", 0, _fake_ctx(),
+        )
+
+    uploaded_item = {
+        **FILE_ITEM, "id": "DRIVE!newfile", "name": "project.json",
+        "parentReference": {"id": ROOT_ID},
+    }
+    with patch("OneDriveFUSE.upload_new_file", return_value=uploaded_item) as mock_upload:
+        trio.run(fuse.release, fi.fh)
+
+    mock_upload.assert_called_once()
+    args, _ = mock_upload.call_args
+    assert args[1] == "project.json"
+    assert fuse._index.lookup(ROOT_ID, "project.json")["id"] == "DRIVE!newfile"


### PR DESCRIPTION
## Summary
- `rename()` looked up items by whatever id the metadata index currently held, including the synthetic `__pending__...` id `create()` inserts before `release()`'s async upload has run
- Passing that synthetic id to the Graph API's move/rename call always fails, breaking the standard atomic-write pattern (write temp file, `rename()` over target) on any freshly created file
- When the source item is still pending upload, the rename is now applied purely locally: the provisional index entry and the in-flight write handle are rewritten so the eventual upload lands under the new name/location — no Graph call, no wait

## Test plan
- [x] `pytest tests/test_onedrive_fuse.py tests/test_metadata_index.py -q` — 61 passed, including 3 new regression tests (no Graph call on rename-before-upload, inode stability across rename, deferred upload uses renamed name/parent)
- [x] Verified full-suite native pyfuse3 crash on test teardown is pre-existing on `main`, unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GXaBsZESojv7qJNFJmftL7